### PR TITLE
Add Model selection to settings

### DIFF
--- a/browser-extension/src/components/settings.tsx
+++ b/browser-extension/src/components/settings.tsx
@@ -16,10 +16,15 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "~components/ui/tooltip";
-import { LLMProvider } from "~models/ai-providers";
-import type { Settings } from "~models/settings";
+import {
+  LLMProvider,
+  OLLAMA_DEFAULT_URL,
+  ProvidersToModels,
+} from "~models/settings";
+import { LLMModel, type Settings } from "~models/settings";
 import { Badge } from "~components/ui/badge";
 import { SiGithub } from "@icons-pack/react-simple-icons";
+import { Separator } from "./ui/separator";
 
 interface SettingsProps {
   settings: Settings;
@@ -39,39 +44,70 @@ export default function SettingsComponent({
   };
 
   const handleProviderChange = (value: LLMProvider) => {
+    // set default url for ollama if not set
+    let url = settings.llm.url;
+    if (value === LLMProvider.OLLAMA && settings.llm.url === "") {
+      url = OLLAMA_DEFAULT_URL;
+    }
+
+    // check if current model is valid for new provider
+    let model = settings.llm.model;
+    if (
+      ProvidersToModels[value].map((m) => m.toString()).includes(model) ===
+      false
+    ) {
+      model = ProvidersToModels[value][0]!;
+    }
+
     setSettings({
       ...settings,
       llm: {
         ...settings.llm,
         provider: value,
+        url: url,
+        model: model,
       },
     });
   };
 
   const [showApiKey, setShowApiKey] = useState(false);
 
-  const handleApiKeyChange = (e: React.ChangeEvent) => {
+  const handleApiKeyChange = (apiKey: string) => {
     setSettings({
       ...settings,
       llm: {
         ...settings.llm,
-        apiKey: e.target.value,
+        apiKey: apiKey,
       },
     });
   };
 
-  const handleUrlChange = (e: React.ChangeEvent) => {
+  const handleUrlChange = (url: string) => {
+    if (url.trim() === "") {
+      url = OLLAMA_DEFAULT_URL;
+    }
+
     setSettings({
       ...settings,
       llm: {
         ...settings.llm,
-        url: e.target.value,
+        url: url,
+      },
+    });
+  };
+
+  const handleModelChange = (value: string) => {
+    setSettings({
+      ...settings,
+      llm: {
+        ...settings.llm,
+        model: value,
       },
     });
   };
 
   return (
-    <div className="p-4 flex-1 flex flex-col">
+    <div className="pt-4 flex-1 flex flex-col overflow-y-auto">
       <div className="flex-1 space-y-6">
         <div className="flex items-center justify-between">
           <div className="flex gap-2">
@@ -119,6 +155,7 @@ export default function SettingsComponent({
         </div>
 
         <div className="space-y-2">
+          <Separator className="my-4" />
           <div className="flex flex-row items-center justify-between">
             <Label htmlFor="llm-provider">LLM Provider</Label>
             <Select
@@ -129,43 +166,81 @@ export default function SettingsComponent({
                 <SelectValue placeholder="Select a provider" />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value={LLMProvider.WASM}>Default Local</SelectItem>
-                <SelectItem value={LLMProvider.OPENAI}>OpenAI</SelectItem>
-                <SelectItem value={LLMProvider.GOOGLE}>
-                  Google Gemini
-                </SelectItem>
-                <SelectItem value={LLMProvider.ANTHROPIC}>Anthropic</SelectItem>
-                <SelectItem value={LLMProvider.OLLAMA}>Ollama</SelectItem>
+                {Object.values(LLMProvider).map((provider) => (
+                  <SelectItem value={provider}>{provider}</SelectItem>
+                ))}
               </SelectContent>
             </Select>
           </div>
 
-          {settings.llm.provider !== LLMProvider.WASM && (
-            <div className="pl-2 space-y-2">
-              <Label htmlFor="api-key">API Key</Label>
-              <Input
-                id="api-key"
-                type={showApiKey ? "text" : "password"}
-                placeholder="Enter your API Key"
-                value={settings.llm.apiKey || ""}
-                onChange={handleApiKeyChange}
-                onFocus={() => setShowApiKey(true)}
-                onBlur={() => setShowApiKey(false)}
-              />
-            </div>
-          )}
-          {settings.llm.provider === LLMProvider.OLLAMA && (
-            <div className="pl-2 space-y-2">
-              <Label htmlFor="url">Url</Label>
-              <Input
-                id="url"
-                type="text"
-                placeholder="Enter your URL"
-                value={settings.llm.url || ""}
-                onChange={handleUrlChange}
-              />
-            </div>
-          )}
+          <div className="space-y-2 pl-2">
+            {settings.llm.provider !== LLMProvider.WASM &&
+              settings.llm.provider !== LLMProvider.OLLAMA && (
+                <div className="flex flex-row items-center gap-2">
+                  <Label htmlFor="api-key">API Key</Label>
+                  <Input
+                    id="api-key"
+                    type={showApiKey ? "text" : "password"}
+                    placeholder="Enter your API Key"
+                    value={settings.llm.apiKey || ""}
+                    onChange={(e) => handleApiKeyChange(e.target.value)}
+                    onFocus={() => setShowApiKey(true)}
+                    onBlur={() => setShowApiKey(false)}
+                  />
+                </div>
+              )}
+            {settings.llm.provider === LLMProvider.OLLAMA && (
+              <div className="flex flex-row items-center gap-2">
+                <Label htmlFor="url">Url</Label>
+                <Input
+                  id="url"
+                  type="text"
+                  placeholder="Enter your URL"
+                  value={settings.llm.url}
+                  onChange={(e) => handleUrlChange(e.target.value)}
+                />
+              </div>
+            )}
+            {ProvidersToModels[settings.llm.provider]?.length > 1 && (
+              <div className="flex flex-row items-center justify-between">
+                <Label htmlFor="llm-model">LLM Model</Label>
+                <Select
+                  value={
+                    ProvidersToModels[settings.llm.provider].includes(
+                      settings.llm.model as LLMModel
+                    )
+                      ? settings.llm.model
+                      : LLMModel.CUSTOM
+                  }
+                  onValueChange={handleModelChange}
+                >
+                  <SelectTrigger id="llm-model">
+                    <SelectValue placeholder="Select a model" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {ProvidersToModels[settings.llm.provider].map((model) => (
+                      <SelectItem value={model}>{model}</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
+            {(settings.llm.model === LLMModel.CUSTOM ||
+              !ProvidersToModels[settings.llm.provider].includes(
+                settings.llm.model as LLMModel
+              )) && (
+              <div className="flex flex-row items-center gap-2">
+                <Label htmlFor="custom-model">Model Id</Label>
+                <Input
+                  id="custom-model"
+                  type="text"
+                  placeholder="Enter the Model Id"
+                  value={settings.llm.model}
+                  onChange={(e) => handleModelChange(e.target.value)}
+                />
+              </div>
+            )}
+          </div>
         </div>
       </div>
 

--- a/browser-extension/src/components/trackingButton.tsx
+++ b/browser-extension/src/components/trackingButton.tsx
@@ -10,7 +10,7 @@ import { useUrl } from "~contexts/UrlContext";
 import { useSettingsStorage } from "~local-storage/settings";
 
 export default function TrackingButton() {
-  const [settings] = useSettingsStorage();
+  const { settings } = useSettingsStorage();
   const { currentUrlCourse } = useUrl();
   const { scanFiles, trackCourse } = useCourse();
 

--- a/browser-extension/src/contexts/UrlContext.tsx
+++ b/browser-extension/src/contexts/UrlContext.tsx
@@ -20,7 +20,7 @@ const UrlContext = createContext<UrlContextType | null>(null);
 
 export function UrlProvider({ children }: { children: ReactNode }) {
   const [currentUrl, setCurrentUrl] = useState<string | undefined>(undefined);
-  const [settings] = useSettingsStorage();
+  const { settings } = useSettingsStorage();
   const { scanFiles } = useCourse();
 
   // query already saved course for current URL

--- a/browser-extension/src/local-storage/settings.ts
+++ b/browser-extension/src/local-storage/settings.ts
@@ -1,13 +1,19 @@
 import { Storage } from "@plasmohq/storage";
 import { useStorage } from "@plasmohq/storage/hook";
-import { LLMProvider } from "~models/ai-providers";
-import type { Settings } from "~models/settings";
+import {
+  type Settings,
+  LLMProvider,
+  ProvidersToModels,
+} from "~models/settings";
 
 const defaultSettings: Settings = {
   darkMode: false,
   autoScrape: false,
   llm: {
     provider: LLMProvider.WASM,
+    apiKey: "",
+    url: "",
+    model: ProvidersToModels[LLMProvider.WASM][0]!.toString(),
   },
 };
 
@@ -31,7 +37,11 @@ export const useSettingsStorage = () => {
     instance: settingsStorageInstance(),
   });
 
-  return [_settings || defaultSettings, setSettings, isLoading] as const;
+  return {
+    settings: _settings || defaultSettings,
+    setSettings,
+    isLoading,
+  } as const;
 };
 
 export const getSettingsFromStorage = async () => {

--- a/browser-extension/src/models/ai-providers.ts
+++ b/browser-extension/src/models/ai-providers.ts
@@ -1,7 +1,0 @@
-export enum LLMProvider {
-  WASM = "wasm",
-  OPENAI = "openai",
-  GOOGLE = "google",
-  ANTHROPIC = "anthropic",
-  OLLAMA = "ollama",
-}

--- a/browser-extension/src/models/settings.ts
+++ b/browser-extension/src/models/settings.ts
@@ -1,9 +1,65 @@
-import type { LLMProvider } from "./ai-providers";
+export enum LLMProvider {
+  WASM = "Default Local",
+  OPENAI = "Open AI",
+  GOOGLE = "Google",
+  ANTHROPIC = "Anthropic",
+  OLLAMA = "Ollama",
+}
+
+export const OLLAMA_DEFAULT_URL = "http://localhost:11434";
+
+export enum LLMModel {
+  // WASM Models
+  QWEN = "Qwen3-0.6B-q4f16_1-MLC",
+  // OpenAI Models
+  GPT_5_2 = "gpt-5.2",
+  GPT_5 = "gpt-5",
+  GPT_5_MINI = "gpt-5-mini",
+
+  // Google Models
+  GEMINI_3_PRO = "gemini-3-pro-preview",
+  GEMINI_3_FLASH = "gemini-3-flash-preview",
+  GEMINI_2_5_FLASH = "gemini-2.5-flash",
+
+  // Anthropic Models
+  CLAUDE_SONNET_4_5 = "claude-sonnet-4-5",
+  CLAUDE_HAIKU_4_5 = "claude-haiku-4-5",
+  CLAUDE_OPUS_4_5 = "claude-opus-4-5",
+
+  // Ollama Models
+  LLAMA3 = "llama3",
+
+  CUSTOM = "custom",
+}
+
+export const ProvidersToModels: Record<LLMProvider, LLMModel[]> = {
+  [LLMProvider.WASM]: [LLMModel.QWEN],
+  [LLMProvider.OPENAI]: [
+    LLMModel.GPT_5_2,
+    LLMModel.GPT_5,
+    LLMModel.GPT_5_MINI,
+    LLMModel.CUSTOM,
+  ],
+  [LLMProvider.GOOGLE]: [
+    LLMModel.GEMINI_3_PRO,
+    LLMModel.GEMINI_3_FLASH,
+    LLMModel.GEMINI_2_5_FLASH,
+    LLMModel.CUSTOM,
+  ],
+  [LLMProvider.ANTHROPIC]: [
+    LLMModel.CLAUDE_SONNET_4_5,
+    LLMModel.CLAUDE_HAIKU_4_5,
+    LLMModel.CLAUDE_OPUS_4_5,
+    LLMModel.CUSTOM,
+  ],
+  [LLMProvider.OLLAMA]: [LLMModel.LLAMA3, LLMModel.CUSTOM],
+};
 
 export interface LLMSettings {
   provider: LLMProvider;
-  apiKey?: string;
-  url?: string;
+  model: string;
+  apiKey: string;
+  url: string; // For Ollama
 }
 
 export interface Settings {

--- a/browser-extension/src/popup.tsx
+++ b/browser-extension/src/popup.tsx
@@ -18,7 +18,7 @@ function IndexPopup() {
     populateMockData(db);
   }, []);
 
-  const [settings] = useSettingsStorage();
+  const { settings } = useSettingsStorage();
   const [alert] = useAlertStorage();
 
   useEffect(() => {

--- a/browser-extension/src/routes/settings/index.tsx
+++ b/browser-extension/src/routes/settings/index.tsx
@@ -4,7 +4,7 @@ import TrackingButton from "~components/trackingButton";
 import { useSettingsStorage } from "~local-storage/settings";
 
 export default function SettingsPage() {
-  const [settings, setSettings] = useSettingsStorage();
+  const { settings, setSettings } = useSettingsStorage();
 
   return (
     <div className="flex flex-col flex-1">

--- a/browser-extension/src/tabs/offscreen.tsx
+++ b/browser-extension/src/tabs/offscreen.tsx
@@ -4,16 +4,15 @@ import { createOpenAI } from "@ai-sdk/openai";
 import { CreateMLCEngine, MLCEngine } from "@mlc-ai/web-llm";
 import type { Flashcard, Unit } from "@reflash/shared";
 import { generateText, type LanguageModel } from "ai";
-import { ollama } from "ollama-ai-provider-v2";
+import { createOllama } from "ollama-ai-provider-v2";
 import * as pdfjsLib from "pdfjs-dist";
 import { useState } from "react";
 
 import { useMessage } from "@plasmohq/messaging/hook";
 
 import { retry } from "~lib/retry";
-import { LLMProvider } from "~models/ai-providers";
 import type { File } from "~models/file";
-import type { LLMSettings } from "~models/settings";
+import { type LLMSettings, LLMProvider } from "~models/settings";
 import type {
   TextItem,
   TextMarkedContent,
@@ -47,7 +46,7 @@ export default function Offscreen() {
       // 1. Start loading model immediately
       let modelLoadingPromise;
       if (req.body.llmSettings.provider === LLMProvider.WASM) {
-        modelLoadingPromise = loadModel();
+        modelLoadingPromise = loadModel(req.body.llmSettings.model);
       }
 
       const file = req.body.file;
@@ -123,13 +122,13 @@ export default function Offscreen() {
     }
   }
 
-  async function loadModel() {
+  async function loadModel(model: string) {
     if (engine !== null) {
       console.debug("Model already loaded");
       return;
     }
 
-    const e = await CreateMLCEngine("Qwen3-0.6B-q4f16_1-MLC", {
+    const e = await CreateMLCEngine(model, {
       // SHOULD ALREADY BE CACHED BY DEFAULT
       //   appConfig: {
       //     useIndexedDBCache: true,
@@ -189,30 +188,28 @@ export default function Offscreen() {
 
     switch (llmSettings.provider) {
       case LLMProvider.OPENAI: {
-        if (!llmSettings.apiKey) throw new Error("OpenAI API Key required");
         const openai = createOpenAI({ apiKey: llmSettings.apiKey });
-        model = openai("gpt-5");
+        model = openai(llmSettings.model);
         break;
       }
 
       case LLMProvider.GOOGLE: {
-        if (!llmSettings.apiKey) throw new Error("Google API Key required");
         const google = createGoogleGenerativeAI({ apiKey: llmSettings.apiKey });
-        model = google("gemini-2.5-flash");
+        model = google(llmSettings.model);
         break;
       }
 
       case LLMProvider.ANTHROPIC: {
-        if (!llmSettings.apiKey) throw new Error("Anthropic API Key required");
         const anthropic = createAnthropic({ apiKey: llmSettings.apiKey });
-        model = anthropic("claude-sonnet-4-20250514");
+        model = anthropic(llmSettings.model);
         break;
       }
 
       case LLMProvider.OLLAMA: {
-        // Ollama runs locally on http://localhost:11434 by default
         // No API Key is required for local Ollama
-        model = ollama("llama3");
+        model = createOllama({
+          baseURL: llmSettings.url,
+        })(llmSettings.model);
         break;
       }
 


### PR DESCRIPTION
Adds a model selection to the settings. The user can now chose different models depending on the provider.

**Steps for testing**:
1. navigate to the settings tab
2. change the provider to anything other than `Defaul local` -> verify that a model selection appears
3. Choose a different model -> verify if you now scan for files, the new model is used in the offscreen
4. Choose `custom` -> verify that you can insert a custom model id and it is then used in the offscreen